### PR TITLE
Ruby/Sapphire Heals in Bag Tracking

### DIFF
--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -5,6 +5,8 @@ GameSettings = {
 	pstats = 0,
 	estats = 0,
 
+	summaryCheckValue = 0, -- The value to check sMonSummaryScreen against (for Ruby/Sapphire)
+
 	sMonSummaryScreen = 0x00000000,
 	sSpecialFlags = 0x00000000, -- [3 = In catching turtorial, 0 = Not in catching turtorial]
 	sBattlerAbilities = 0x00000000,
@@ -120,6 +122,7 @@ function GameSettings.setGameAsRuby(gameversion)
 	if gameversion == 0x00410000 then
 		print("ROM Detected: Pokemon Ruby v1.0")
 
+		GameSettings.summaryCheckValue = 69 --nice
 		GameSettings.sMonSummaryScreen = 0x03001770 + 0x004 -- gMain + callback2 offset
 		GameSettings.sSpecialFlags = 0x0202e8e2 -- gUnknown_0202E8E2
 		GameSettings.sBattlerAbilities = 0x0203926c -- gAbilitiesPerBank
@@ -141,6 +144,7 @@ function GameSettings.setGameAsRuby(gameversion)
 	elseif gameversion == 0x01400000 then
 		print("ROM Detected: Pokemon Ruby v1.1")
 
+		GameSettings.summaryCheckValue = 101
 		GameSettings.sMonSummaryScreen = 0x03001770 + 0x004 -- gMain + callback2 offset
 		GameSettings.sSpecialFlags = 0x0202e8e2 -- gUnknown_0202E8E2
 		GameSettings.sBattlerAbilities = 0x0203926c -- gAbilitiesPerBank
@@ -162,6 +166,7 @@ function GameSettings.setGameAsRuby(gameversion)
 	elseif gameversion == 0x023F0000 then
 		print("ROM Detected: Pokemon Ruby v1.2")
 
+		GameSettings.summaryCheckValue = 101
 		GameSettings.sMonSummaryScreen = 0x03001770 + 0x004 -- gMain + callback2 offset
 		GameSettings.sSpecialFlags = 0x0202e8e2 -- gUnknown_0202E8E2
 		GameSettings.sBattlerAbilities = 0x0203926c -- gAbilitiesPerBank
@@ -188,6 +193,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 	if gameversion == 0x00550000 then
 		print("ROM Detected: Pokemon Sapphire v1.0")
 
+		GameSettings.summaryCheckValue = 69
 		GameSettings.sMonSummaryScreen = 0x03001770 + 0x004 -- gMain + callback2 offset
 		GameSettings.sSpecialFlags = 0x0202e8e2 -- gUnknown_0202E8E2
 		GameSettings.sBattlerAbilities = 0x0203926c -- gAbilitiesPerBank
@@ -209,6 +215,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 	elseif gameversion == 0x1540000 then
 		print("ROM Detected: Pokemon Sapphire v1.1")
 
+		GameSettings.summaryCheckValue = 101
 		GameSettings.sMonSummaryScreen = 0x03001770 + 0x004 -- gMain + callback2 offset
 		GameSettings.sSpecialFlags = 0x0202e8e2 -- gUnknown_0202E8E2
 		GameSettings.sBattlerAbilities = 0x0203926c -- gAbilitiesPerBank
@@ -230,6 +237,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 	elseif gameversion == 0x02530000 then
 		print("ROM Detected: Pokemon Sapphire v1.2")
 
+		GameSettings.summaryCheckValue = 101
 		GameSettings.sMonSummaryScreen = 0x03001770 + 0x004 -- gMain + callback2 offset
 		GameSettings.sSpecialFlags = 0x0202e8e2 -- gUnknown_0202E8E2
 		GameSettings.sBattlerAbilities = 0x0203926c -- gAbilitiesPerBank

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -134,9 +134,9 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gSaveBlock2ptr = 0x00000000
 		GameSettings.bagEncryptionKeyOffset = 0x00
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x000
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x000
-		GameSettings.bagPocket_Items_Size = 30 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
+		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
+		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
+		GameSettings.bagPocket_Items_Size = 20 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
 		GameSettings.bagPocket_Berries_Size = 46
 	elseif gameversion == 0x01400000 then
 		print("ROM Detected: Pokemon Ruby v1.1")
@@ -155,9 +155,9 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gSaveBlock2ptr = 0x00000000
 		GameSettings.bagEncryptionKeyOffset = 0x00
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x000
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x000
-		GameSettings.bagPocket_Items_Size = 30 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
+		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
+		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
+		GameSettings.bagPocket_Items_Size = 20 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
 		GameSettings.bagPocket_Berries_Size = 46
 	elseif gameversion == 0x023F0000 then
 		print("ROM Detected: Pokemon Ruby v1.2")
@@ -176,9 +176,9 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gSaveBlock2ptr = 0x00000000
 		GameSettings.bagEncryptionKeyOffset = 0x00
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x000
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x000
-		GameSettings.bagPocket_Items_Size = 30 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
+		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
+		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
+		GameSettings.bagPocket_Items_Size = 20 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
 		GameSettings.bagPocket_Berries_Size = 46
 	end
 end
@@ -202,9 +202,9 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gSaveBlock2ptr = 0x00000000
 		GameSettings.bagEncryptionKeyOffset = 0x00
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x000
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x000
-		GameSettings.bagPocket_Items_Size = 30 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
+		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
+		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
+		GameSettings.bagPocket_Items_Size = 20 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
 		GameSettings.bagPocket_Berries_Size = 46
 	elseif gameversion == 0x1540000 then
 		print("ROM Detected: Pokemon Sapphire v1.1")
@@ -223,9 +223,9 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gSaveBlock2ptr = 0x00000000
 		GameSettings.bagEncryptionKeyOffset = 0x00
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x000
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x000
-		GameSettings.bagPocket_Items_Size = 30 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
+		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
+		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
+		GameSettings.bagPocket_Items_Size = 20 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
 		GameSettings.bagPocket_Berries_Size = 46
 	elseif gameversion == 0x02530000 then
 		print("ROM Detected: Pokemon Sapphire v1.2")
@@ -244,9 +244,9 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gSaveBlock2ptr = 0x00000000
 		GameSettings.bagEncryptionKeyOffset = 0x00
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x000
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x000
-		GameSettings.bagPocket_Items_Size = 30 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
+		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
+		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
+		GameSettings.bagPocket_Items_Size = 20 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
 		GameSettings.bagPocket_Berries_Size = 46
 	end
 end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -97,8 +97,8 @@ function Program.updateTrackedAndCurrentData()
 			-- Check for if summary screen is being shown
 			if not Tracker.Data.hasCheckedSummary then
 				local summaryCheck = Memory.readbyte(GameSettings.sMonSummaryScreen)
-				if GameSettings.game == 1 then -- Ruby/Sapphire specifically check for value of 101, not non-zero
-					if summaryCheck == 101 then
+				if GameSettings.game == 1 then -- Ruby/Sapphire uses a different memory address and checks for a specific value
+					if summaryCheck == GameSettings.summaryCheckValue then
 						Tracker.Data.hasCheckedSummary = true
 					end
 				else

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -656,9 +656,11 @@ function Program.getHealingItemsFromMemory()
 	-- end
 
 	-- I believe this key has to be looked-up each time, as the ptr changes periodically
-	if GameSettings.gSaveBlock2ptr == 0 then return nil end -- safety check since ruby/sapphire ptr location is unknown
-	local saveBlock2addr = Memory.readdword(GameSettings.gSaveBlock2ptr)
-	local key = Memory.readword(saveBlock2addr + GameSettings.bagEncryptionKeyOffset)
+	local key = nil -- Ruby/Sapphire don't have an encryption key
+	if GameSettings.bagEncryptionKeyOffset ~= 0 then
+    	local saveBlock2addr = Memory.readdword(GameSettings.gSaveBlock2ptr)
+    	key = Memory.readword(saveBlock2addr + GameSettings.bagEncryptionKeyOffset)
+	end
 
 	local healingItems = {}
 
@@ -673,8 +675,9 @@ function Program.getHealingItemsFromMemory()
 			--read 4 bytes at once, should be less expensive than reading two sets of 2 bytes.
 			local itemid_and_quantity = Memory.readdword(address + i * 0x4)
 			local itemID = Utils.getbits(itemid_and_quantity, 0, 16)
-			if itemID ~= 0 then
-				local quantity = bit.bxor(Utils.getbits(itemid_and_quantity, 16, 16), key)
+			if itemID ~= 0 and MiscData.healingItems[itemID] ~= nil then
+				local quantity = Utils.getbits(itemid_and_quantity, 16, 16)
+				if key ~= nil then quantity = bit.bxor(quantity, key) end
 				healingItems[itemID] = quantity
 			end
 		end


### PR DESCRIPTION
This adds in heals in bag tracking support for Ruby and Sapphire

Turns out the bag items are not encrypted in RS - https://github.com/pret/pokeruby/blob/master/src/item.c
So `Program.lua` has been updated to account for this

bagPocket offsets were found here - https://github.com/pret/pokeruby/blob/676745e7c6fbd967d7c61b00bdf25f08be2d1846/include/global.h#L687

For the `GameSettings.bagPocket_Items_Size` and `GameSettings.bagPocket_Berries_Size` values i used values from here, not sure if these are correct as I don't know where these values were taken from for FRLG and Emerald - https://github.com/pret/pokeruby/blob/2162e948d1889cbf5c651b9747dab1194323f2da/src/item_menu.c#L152

I have tested this on RS v1.0, 1.1, and 1.2 and it seems to be working. It didn't seem to break on my Firered and Emerald roms